### PR TITLE
Procedural Bone Chain (PBC) コンポーネントの追加

### DIFF
--- a/Assets/Prefab/Entity/FrilledShark.prefab
+++ b/Assets/Prefab/Entity/FrilledShark.prefab
@@ -152,6 +152,9 @@ PrefabInstance:
     - targetCorrespondingSourceObject: {fileID: 919132149155446097, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
       insertIndex: -1
       addedObject: {fileID: 5025213449896169461}
+    - targetCorrespondingSourceObject: {fileID: -8876800046026049745, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 549921085443255978}
   m_SourcePrefab: {fileID: 100100000, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
 --- !u!1 &102363748872707561 stripped
 GameObject:
@@ -232,13 +235,74 @@ BoxCollider:
   serializedVersion: 3
   m_Size: {x: 0.31118774, y: 0.25231934, z: 2.5126953}
   m_Center: {x: -0.061843872, y: 0.12319946, z: 0.24377441}
+--- !u!1 &677096834838058903 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: -8876800046026049745, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
+  m_PrefabInstance: {fileID: 984813428459856056}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &549921085443255978
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 677096834838058903}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 960d5ef7f645818458acbc11b8e27eca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::Blue.Entity.Common.ProceduralBoneChain
+  segments:
+  - bone: {fileID: 4637777429877914611}
+    damping: 0.1
+  - bone: {fileID: 6770706540928511202}
+    damping: 0.15
+  - bone: {fileID: 9177907062376214764}
+    damping: 0.2
+  - bone: {fileID: 8273132938453814594}
+    damping: 0.25
+  - bone: {fileID: 8664379918331621826}
+    damping: 0.3
+  rotationSpeed: 5
+  dampingFalloff: 0.5
+  constrainBoneLength: 1
+  maxBendAngle: 45
+  branches: []
+  showDebugGizmos: 0
+  debugBoneColor: {r: 0, g: 1, b: 1, a: 1}
+  debugConstraintColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
 --- !u!137 &2977448166610132700 stripped
 SkinnedMeshRenderer:
   m_CorrespondingSourceObject: {fileID: 2664098864995057252, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
   m_PrefabInstance: {fileID: 984813428459856056}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &4637777429877914611 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5617801385246464843, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
+  m_PrefabInstance: {fileID: 984813428459856056}
+  m_PrefabAsset: {fileID: 0}
 --- !u!95 &6683437717510085929 stripped
 Animator:
   m_CorrespondingSourceObject: {fileID: 5866666021909216657, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
+  m_PrefabInstance: {fileID: 984813428459856056}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &6770706540928511202 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -3432689451567461286, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
+  m_PrefabInstance: {fileID: 984813428459856056}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8273132938453814594 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 9185883137609952762, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
+  m_PrefabInstance: {fileID: 984813428459856056}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8664379918331621826 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8472622445068374394, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
+  m_PrefabInstance: {fileID: 984813428459856056}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &9177907062376214764 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -939920535052496812, guid: e44ffa41927761443926317ac40ce6f5, type: 3}
   m_PrefabInstance: {fileID: 984813428459856056}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Scripts/Entity/Common/BoneChainBranch.cs
+++ b/Assets/Scripts/Entity/Common/BoneChainBranch.cs
@@ -1,0 +1,144 @@
+using UnityEngine;
+using System;
+
+namespace Blue.Entity.Common
+{
+    /// <summary>
+    /// 分岐ボーン（ヒレなど）を制御するクラス
+    /// メインチェーンの特定セグメントに追従する
+    /// </summary>
+    [Serializable]
+    public class BoneChainBranch
+    {
+        [Header("Branch Settings")]
+        [SerializeField] private string branchName;
+        [SerializeField] private Transform branchRoot;
+        [SerializeField] private Transform[] branchBones;
+
+        [Header("Follow Settings")]
+        [Tooltip("追従する親セグメントのインデックス（0始まり）")]
+        [SerializeField] private int parentSegmentIndex;
+        [SerializeField, Range(0f, 1f)] private float followStrength = 0.5f;
+        [SerializeField, Range(0f, 1f)] private float damping = 0.2f;
+        [SerializeField] private bool enabled = true;
+
+        // ランタイムキャッシュ
+        private float[] boneLengths;
+        private Quaternion[] initialLocalRotations;
+        private Vector3[] previousPositions;
+        private bool isInitialized;
+
+        // プロパティ
+        public string BranchName => branchName;
+        public Transform BranchRoot => branchRoot;
+        public Transform[] BranchBones => branchBones;
+        public int ParentSegmentIndex => parentSegmentIndex;
+        public float FollowStrength => followStrength;
+        public float Damping => damping;
+        public bool Enabled { get => enabled; set => enabled = value; }
+        public bool IsInitialized => isInitialized;
+
+        /// <summary>
+        /// 分岐の初期化
+        /// </summary>
+        public void Initialize()
+        {
+            if (branchBones == null || branchBones.Length == 0)
+            {
+                Debug.LogWarning($"[BoneChainBranch] {branchName}: No branch bones defined.");
+                return;
+            }
+
+            boneLengths = new float[branchBones.Length];
+            initialLocalRotations = new Quaternion[branchBones.Length];
+            previousPositions = new Vector3[branchBones.Length];
+
+            for (int i = 0; i < branchBones.Length; i++)
+            {
+                if (branchBones[i] == null) continue;
+
+                initialLocalRotations[i] = branchBones[i].localRotation;
+                previousPositions[i] = branchBones[i].position;
+
+                // ボーン長を計算
+                if (i < branchBones.Length - 1 && branchBones[i + 1] != null)
+                {
+                    boneLengths[i] = Vector3.Distance(
+                        branchBones[i].position,
+                        branchBones[i + 1].position
+                    );
+                }
+            }
+
+            isInitialized = true;
+        }
+
+        /// <summary>
+        /// 分岐ボーンの更新
+        /// </summary>
+        /// <param name="parentVelocity">親セグメントの速度</param>
+        /// <param name="deltaTime">デルタタイム</param>
+        public void UpdateBranch(Vector3 parentVelocity, float deltaTime)
+        {
+            if (!enabled || !isInitialized || branchBones == null) return;
+
+            for (int i = 0; i < branchBones.Length; i++)
+            {
+                if (branchBones[i] == null) continue;
+
+                // 親の動きに対する遅延追従（速度の逆方向に少し遅れる）
+                Vector3 inertiaOffset = -parentVelocity * followStrength * deltaTime;
+
+                // 目標位置を計算
+                Vector3 targetPos = branchBones[i].position + inertiaOffset;
+
+                // 回転の計算（前のボーンを向く）
+                if (i > 0 && branchBones[i - 1] != null)
+                {
+                    Vector3 dirToParent = (branchBones[i - 1].position - branchBones[i].position).normalized;
+                    if (dirToParent.sqrMagnitude > 0.001f)
+                    {
+                        Quaternion targetRot = Quaternion.LookRotation(dirToParent);
+                        branchBones[i].rotation = Quaternion.Slerp(
+                            branchBones[i].rotation,
+                            targetRot,
+                            damping
+                        );
+                    }
+                }
+
+                // ボーン長の制約を適用
+                if (i > 0 && branchBones[i - 1] != null && boneLengths[i - 1] > 0f)
+                {
+                    Vector3 parentBonePos = branchBones[i - 1].position;
+                    Vector3 dir = (branchBones[i].position - parentBonePos).normalized;
+
+                    if (dir.sqrMagnitude < 0.001f)
+                    {
+                        dir = -branchBones[i - 1].forward;
+                    }
+
+                    branchBones[i].position = parentBonePos + dir * boneLengths[i - 1];
+                }
+
+                previousPositions[i] = branchBones[i].position;
+            }
+        }
+
+        /// <summary>
+        /// 分岐を初期姿勢にリセット
+        /// </summary>
+        public void ResetToInitialPose()
+        {
+            if (!isInitialized || branchBones == null) return;
+
+            for (int i = 0; i < branchBones.Length; i++)
+            {
+                if (branchBones[i] != null)
+                {
+                    branchBones[i].localRotation = initialLocalRotations[i];
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Entity/Common/BoneChainBranch.cs.meta
+++ b/Assets/Scripts/Entity/Common/BoneChainBranch.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d69f51a4991b5e3429814a8c1eceb361

--- a/Assets/Scripts/Entity/Common/BoneChainSegment.cs
+++ b/Assets/Scripts/Entity/Common/BoneChainSegment.cs
@@ -1,0 +1,77 @@
+using UnityEngine;
+using System;
+
+namespace Blue.Entity.Common
+{
+    /// <summary>
+    /// 個々のボーンセグメントのデータと計算を担当
+    /// ProceduralBoneChainから使用される
+    /// </summary>
+    [Serializable]
+    public class BoneChainSegment
+    {
+        [Header("Bone Reference")]
+        [SerializeField] private Transform bone;
+
+        [Header("Settings")]
+        [Tooltip("追従の遅れ（0=即座に追従、1=ほぼ追従しない）")]
+        [SerializeField, Range(0f, 0.99f)] private float damping = 0.1f;
+
+        // ランタイム用キャッシュ（非シリアライズ）
+        private float cachedBoneLength;
+        private Quaternion initialLocalRotation;
+        private Vector3 previousPosition;
+        private Quaternion currentRotation;
+        private bool isInitialized;
+
+        // プロパティ
+        public Transform Bone => bone;
+        public float Damping => damping;
+        public float BoneLength => cachedBoneLength;
+        public Quaternion InitialLocalRotation => initialLocalRotation;
+        public Vector3 PreviousPosition { get => previousPosition; set => previousPosition = value; }
+        public Quaternion CurrentRotation { get => currentRotation; set => currentRotation = value; }
+        public bool IsInitialized => isInitialized;
+
+        /// <summary>
+        /// 初期化：ボーン長と初期回転をキャッシュ
+        /// </summary>
+        /// <param name="nextBone">次のボーン（末端の場合はnull）</param>
+        public void Initialize(Transform nextBone)
+        {
+            if (bone == null)
+            {
+                Debug.LogWarning("[BoneChainSegment] Bone reference is null.");
+                return;
+            }
+
+            initialLocalRotation = bone.localRotation;
+            previousPosition = bone.position;
+            currentRotation = bone.rotation;
+
+            // ボーン長を計算（次のボーンがある場合）
+            if (nextBone != null)
+            {
+                cachedBoneLength = Vector3.Distance(bone.position, nextBone.position);
+            }
+            else
+            {
+                cachedBoneLength = 0f;
+            }
+
+            isInitialized = true;
+        }
+
+        /// <summary>
+        /// ボーンをリセット（初期姿勢に戻す）
+        /// </summary>
+        public void ResetToInitialPose()
+        {
+            if (bone != null && isInitialized)
+            {
+                bone.localRotation = initialLocalRotation;
+                currentRotation = bone.rotation;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Entity/Common/BoneChainSegment.cs.meta
+++ b/Assets/Scripts/Entity/Common/BoneChainSegment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 676dbdd64585d9c42ad300c72ac4d616

--- a/Assets/Scripts/Entity/Common/ProceduralBoneChain.cs
+++ b/Assets/Scripts/Entity/Common/ProceduralBoneChain.cs
@@ -1,0 +1,367 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace Blue.Entity.Common
+{
+    /// <summary>
+    /// 魚の胴体のようなチェーンボーンのプロシージャルIK
+    /// 頭が先導し、胴体・尻尾が追従する
+    /// ボーン長を保持しながら滑らかに曲がる
+    /// </summary>
+    public class ProceduralBoneChain : MonoBehaviour
+    {
+        [Header("Chain Settings")]
+        [Tooltip("先頭ボーン（頭）から末端ボーン（尻尾）への順序で設定")]
+        [SerializeField] private List<BoneChainSegment> segments = new List<BoneChainSegment>();
+
+        [Header("Follow Settings")]
+        [Tooltip("回転の追従速度（大きいほど速く追従）")]
+        [SerializeField, Range(1f, 50f)] private float rotationSpeed = 15f;
+
+        [Tooltip("末端に向かうほど遅延を増加させる係数")]
+        [SerializeField, Range(0f, 2f)] private float dampingFalloff = 0.5f;
+
+        [Header("Constraints")]
+        [SerializeField] private bool constrainBoneLength = true;
+        [SerializeField, Range(0f, 180f)] private float maxBendAngle = 60f;
+
+        [Header("Branch Settings")]
+        [SerializeField] private List<BoneChainBranch> branches = new List<BoneChainBranch>();
+
+        [Header("Debug")]
+        [SerializeField] private bool showDebugGizmos = false;
+        [SerializeField] private Color debugBoneColor = Color.cyan;
+        [SerializeField] private Color debugConstraintColor = Color.yellow;
+
+        // ランタイム
+        private bool isInitialized = false;
+        private Transform headBone;
+        private Vector3 previousHeadPosition;
+
+        // プロパティ
+        public List<BoneChainSegment> Segments => segments;
+        public List<BoneChainBranch> Branches => branches;
+        public bool IsInitialized => isInitialized;
+        public float RotationSpeed { get => rotationSpeed; set => rotationSpeed = Mathf.Max(1f, value); }
+
+        #region Unity Lifecycle
+
+        private void Start()
+        {
+            Initialize();
+        }
+
+        /// <summary>
+        /// LateUpdateでAnimator更新後にボーンを制御
+        /// </summary>
+        private void LateUpdate()
+        {
+            if (!isInitialized || segments.Count == 0) return;
+
+            UpdateBoneChain();
+            UpdateBranches();
+
+            // 状態を保存
+            if (headBone != null)
+            {
+                previousHeadPosition = headBone.position;
+            }
+        }
+
+        #endregion
+
+        #region Initialization
+
+        /// <summary>
+        /// ボーンチェーンの初期化
+        /// </summary>
+        public void Initialize()
+        {
+            if (segments.Count == 0)
+            {
+                Debug.LogWarning($"[ProceduralBoneChain] {name}: No segments defined.");
+                return;
+            }
+
+            // 各セグメントを初期化
+            for (int i = 0; i < segments.Count; i++)
+            {
+                Transform nextBone = (i < segments.Count - 1)
+                    ? segments[i + 1].Bone
+                    : null;
+                segments[i].Initialize(nextBone);
+            }
+
+            // 先頭ボーンをキャッシュ
+            headBone = segments[0].Bone;
+            if (headBone != null)
+            {
+                previousHeadPosition = headBone.position;
+            }
+
+            // 分岐の初期化
+            foreach (BoneChainBranch branch in branches)
+            {
+                branch.Initialize();
+            }
+
+            isInitialized = true;
+        }
+
+        #endregion
+
+        #region Bone Chain Update
+
+        /// <summary>
+        /// ボーンチェーン全体の更新
+        /// </summary>
+        private void UpdateBoneChain()
+        {
+            if (headBone == null) return;
+
+            float deltaTime = Time.deltaTime;
+            if (deltaTime <= 0f) return;
+
+            // 先頭ボーンの回転を保存（先頭は制御しない）
+            segments[0].CurrentRotation = headBone.rotation;
+            segments[0].PreviousPosition = headBone.position;
+
+            // 後続のボーンを順番に更新（前から後ろへ）
+            for (int i = 1; i < segments.Count; i++)
+            {
+                BoneChainSegment currentSegment = segments[i];
+                BoneChainSegment parentSegment = segments[i - 1];
+
+                if (currentSegment.Bone == null || parentSegment.Bone == null) continue;
+
+                // 末端に向かうほどダンピングを増加
+                float chainProgress = (float)i / (segments.Count - 1);
+                float additionalDamping = chainProgress * dampingFalloff;
+
+                UpdateSegment(currentSegment, parentSegment, deltaTime, additionalDamping);
+            }
+        }
+
+        /// <summary>
+        /// 個別セグメントの更新
+        /// </summary>
+        private void UpdateSegment(BoneChainSegment segment, BoneChainSegment parent, float deltaTime, float additionalDamping)
+        {
+            Transform bone = segment.Bone;
+            Transform parentBone = parent.Bone;
+
+            // === Step 1: 位置の制約（ボーン長を保持） ===
+            if (constrainBoneLength && segment.BoneLength > 0f)
+            {
+                // 現在の位置から親への方向を取得
+                Vector3 dirFromParent = (bone.position - parentBone.position);
+
+                if (dirFromParent.sqrMagnitude < 0.0001f)
+                {
+                    // ほぼ同じ位置の場合、親の後方を使用
+                    dirFromParent = -parentBone.forward;
+                }
+                else
+                {
+                    dirFromParent.Normalize();
+                }
+
+                // 親から固定距離の位置に配置
+                bone.position = parentBone.position + dirFromParent * segment.BoneLength;
+            }
+
+            // === Step 2: 回転の追従（親の回転に滑らかに追従） ===
+
+            // 目標回転 = 親の回転（ローカルオフセットを適用）
+            Quaternion targetRotation = parentBone.rotation * segment.InitialLocalRotation;
+
+            // 角度制限の適用
+            if (maxBendAngle < 180f)
+            {
+                targetRotation = ApplyAngleConstraint(targetRotation, parent.CurrentRotation, segment.InitialLocalRotation);
+            }
+
+            // ダンピング計算（シンプルな指数減衰）
+            float effectiveDamping = segment.Damping + additionalDamping;
+            effectiveDamping = Mathf.Clamp01(effectiveDamping);
+
+            // t = 1 - damping^(deltaTime * speed) の近似
+            float t = 1f - Mathf.Pow(effectiveDamping, deltaTime * rotationSpeed);
+            t = Mathf.Clamp01(t);
+
+            // 現在の回転から目標回転へ補間
+            Quaternion newRotation = Quaternion.Slerp(segment.CurrentRotation, targetRotation, t);
+
+            bone.rotation = newRotation;
+            segment.CurrentRotation = newRotation;
+            segment.PreviousPosition = bone.position;
+        }
+
+        /// <summary>
+        /// 曲がり角度の制限を適用
+        /// </summary>
+        private Quaternion ApplyAngleConstraint(Quaternion targetRotation, Quaternion parentRotation, Quaternion initialLocalRotation)
+        {
+            // 親からの相対回転を計算
+            Quaternion relativeRotation = Quaternion.Inverse(parentRotation) * targetRotation;
+
+            // 初期ローカル回転からの差分を取得
+            Quaternion deltaFromInitial = Quaternion.Inverse(initialLocalRotation) * relativeRotation;
+
+            // 角度を取得
+            deltaFromInitial.ToAngleAxis(out float angle, out Vector3 axis);
+
+            // 角度が180度を超える場合は反転（Quaternionの特性上）
+            if (angle > 180f)
+            {
+                angle = 360f - angle;
+                axis = -axis;
+            }
+
+            // 角度を制限
+            if (angle > maxBendAngle)
+            {
+                Quaternion limitedDelta = Quaternion.AngleAxis(maxBendAngle, axis);
+                return parentRotation * initialLocalRotation * limitedDelta;
+            }
+
+            return targetRotation;
+        }
+
+        #endregion
+
+        #region Branch Update
+
+        /// <summary>
+        /// 分岐ボーンの更新
+        /// </summary>
+        private void UpdateBranches()
+        {
+            if (branches.Count == 0) return;
+
+            float deltaTime = Time.deltaTime;
+            if (deltaTime <= 0f) return;
+
+            foreach (BoneChainBranch branch in branches)
+            {
+                if (!branch.Enabled) continue;
+                if (branch.ParentSegmentIndex < 0 || branch.ParentSegmentIndex >= segments.Count) continue;
+
+                BoneChainSegment parentSegment = segments[branch.ParentSegmentIndex];
+                if (parentSegment.Bone == null) continue;
+
+                // 親セグメントの速度を計算
+                Vector3 parentVelocity = (parentSegment.Bone.position - parentSegment.PreviousPosition) / deltaTime;
+
+                branch.UpdateBranch(parentVelocity, deltaTime);
+            }
+        }
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// 分岐の有効/無効を切り替え（名前指定）
+        /// </summary>
+        public void SetBranchEnabled(string branchName, bool enabled)
+        {
+            BoneChainBranch branch = branches.Find(b => b.BranchName == branchName);
+            if (branch != null)
+            {
+                branch.Enabled = enabled;
+            }
+        }
+
+        /// <summary>
+        /// 分岐の有効/無効を切り替え（インデックス指定）
+        /// </summary>
+        public void SetBranchEnabled(int index, bool enabled)
+        {
+            if (index >= 0 && index < branches.Count)
+            {
+                branches[index].Enabled = enabled;
+            }
+        }
+
+        /// <summary>
+        /// 即座に全ボーンをリセット
+        /// </summary>
+        public void ResetToInitialPose()
+        {
+            foreach (BoneChainSegment segment in segments)
+            {
+                segment.ResetToInitialPose();
+            }
+
+            foreach (BoneChainBranch branch in branches)
+            {
+                branch.ResetToInitialPose();
+            }
+        }
+
+        #endregion
+
+        #region Debug Gizmos
+
+#if UNITY_EDITOR
+        private void OnDrawGizmosSelected()
+        {
+            if (!showDebugGizmos || segments.Count == 0) return;
+
+            // ボーンチェーンの描画
+            Gizmos.color = debugBoneColor;
+            for (int i = 0; i < segments.Count - 1; i++)
+            {
+                BoneChainSegment current = segments[i];
+                BoneChainSegment next = segments[i + 1];
+
+                if (current.Bone != null && next.Bone != null)
+                {
+                    Gizmos.DrawLine(current.Bone.position, next.Bone.position);
+                    Gizmos.DrawWireSphere(current.Bone.position, 0.02f);
+                }
+            }
+
+            // 最後のボーン
+            if (segments.Count > 0 && segments[segments.Count - 1].Bone != null)
+            {
+                Gizmos.DrawWireSphere(segments[segments.Count - 1].Bone.position, 0.02f);
+            }
+
+            // ボーン長制約の表示
+            if (constrainBoneLength)
+            {
+                Gizmos.color = debugConstraintColor;
+                for (int i = 1; i < segments.Count; i++)
+                {
+                    BoneChainSegment segment = segments[i];
+                    BoneChainSegment parent = segments[i - 1];
+
+                    if (parent.Bone != null && segment.BoneLength > 0f)
+                    {
+                        Gizmos.DrawWireSphere(parent.Bone.position, segment.BoneLength);
+                    }
+                }
+            }
+
+            // 分岐の描画
+            Gizmos.color = Color.green;
+            foreach (BoneChainBranch branch in branches)
+            {
+                if (branch.BranchBones == null) continue;
+
+                for (int i = 0; i < branch.BranchBones.Length - 1; i++)
+                {
+                    if (branch.BranchBones[i] != null && branch.BranchBones[i + 1] != null)
+                    {
+                        Gizmos.DrawLine(branch.BranchBones[i].position, branch.BranchBones[i + 1].position);
+                    }
+                }
+            }
+        }
+#endif
+
+        #endregion
+    }
+}

--- a/Assets/Scripts/Entity/Common/ProceduralBoneChain.cs.meta
+++ b/Assets/Scripts/Entity/Common/ProceduralBoneChain.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 960d5ef7f645818458acbc11b8e27eca


### PR DESCRIPTION
## Summary
- 魚の胴体のような長いボーンチェーンをプロシージャルに制御するコンポーネントを追加
- 頭が先導し、胴体・尻尾が滑らかに追従する動きを実現
- ボーン長を保持（伸び縮みしない）

## 追加ファイル
- `Assets/Scripts/Entity/Common/ProceduralBoneChain.cs` - メインコンポーネント
- `Assets/Scripts/Entity/Common/BoneChainSegment.cs` - 個々のボーンセグメント
- `Assets/Scripts/Entity/Common/BoneChainBranch.cs` - 分岐（ヒレなど）用

## 使い方

### 1. コンポーネントをアタッチ
魚のGameObjectに `ProceduralBoneChain` をアタッチ

### 2. Segmentsを設定
Inspectorで **頭→尻尾の順** にボーンを追加：
```
Segments:
  [0] Bone: Head        Damping: 0.1
  [1] Bone: Spine1      Damping: 0.15
  [2] Bone: Spine2      Damping: 0.2
  [3] Bone: Tail        Damping: 0.25
```

### 3. パラメータ調整
| パラメータ | 説明 | 推奨値 |
|-----------|------|--------|
| Rotation Speed | 回転の追従速度（大きいほど速い） | 10〜20 |
| Damping Falloff | 末端への遅延増加係数 | 0.3〜0.7 |
| Max Bend Angle | 各ボーンの最大曲がり角度 | 45〜90 |
| 各セグメントのDamping | 個別の遅延（0=即追従、0.5=遅い） | 0.05〜0.3 |

### 4. 分岐の設定（オプション）
ヒレなどを追加する場合：
```
Branches:
  [0] BranchName: "DorsalFin"
      ParentSegmentIndex: 1  (どのセグメントに追従するか)
      BranchBones: [Fin1, Fin2, Fin3]
      FollowStrength: 0.5
      Damping: 0.2
```

## 技術的な注意
- **LateUpdate** で実行されるため、Animatorの後にボーンを上書き
- ボーン長は初期化時にキャッシュされ、毎フレーム固定距離を保持
- 先頭ボーン（頭）は制御せず、他のシステム（BaseSwimmerなど）に委ねる

🤖 Generated with [Claude Code](https://claude.com/claude-code)