### PR TITLE
Add IPlayerProgressPersistence abstraction and refactor player save/load to use it

### DIFF
--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -56,6 +56,7 @@ namespace Blue.Player
         private int oxygenDecreaseAmount = 1;
         private bool fuelDepleted = false;
         private float fuelDepletedTimer = 0f;
+        private IPlayerProgressPersistence persistence;
 
         public InventoryModel Inventory => model.Inventory;
         public QuickSlotModel QuickSlot => model.QuickSlot;
@@ -87,11 +88,12 @@ namespace Blue.Player
             }
             Instance = this;
             inputHandler = new PlayerInputHandler();
+            persistence = new SaveDataPlayerProgressPersistence();
 
             // セーブデータから読み込み
-            InventoryModel playerInventory = SaveDataConverter.LoadPlayerInventory();
-            QuickSlotModel quickSlot = SaveDataConverter.LoadQuickSlot();
-            model = new PlayerModel(data, playerInventory, quickSlot);
+            InventoryModel playerInventory = persistence.LoadPlayerInventory();
+            QuickSlotModel quickSlot = persistence.LoadQuickSlot();
+            model = new PlayerModel(data, playerInventory, quickSlot, persistence: persistence);
 
             model.Status.OnHPChanged += HandleHPChanged;
             model.OnOxygenChanged += HandleOxygenChanged;
@@ -538,12 +540,12 @@ namespace Blue.Player
 
         private void OnInventoryChanged()
         {
-            SaveDataConverter.SavePlayerInventory(Inventory);
+            persistence.SavePlayerInventory(Inventory);
         }
 
         private void OnQuickSlotChanged()
         {
-            SaveDataConverter.SaveQuickSlot(QuickSlot);
+            persistence.SaveQuickSlot(QuickSlot);
         }
     }
 }

--- a/Assets/Scripts/Player/PlayerModel.cs
+++ b/Assets/Scripts/Player/PlayerModel.cs
@@ -13,21 +13,28 @@ namespace Blue.Player
         private InventoryModel inventory = new InventoryModel();
         private Dictionary<EntityData, int> capturedEntities = new Dictionary<EntityData, int>();
         private QuickSlotModel quickSlotModel;
+        private IPlayerProgressPersistence persistence;
         private int maxOxygen = 100;
         private int oxygen;
         private float maxFuel = 100f;
         private float fuel;
         private float depth;
 
-        public PlayerModel(EntityData data, InventoryModel inventory = null, QuickSlotModel quickSlot = null, int? initialOxygen = null) : base(data)
+        public PlayerModel(
+            EntityData data,
+            InventoryModel inventory = null,
+            QuickSlotModel quickSlot = null,
+            int? initialOxygen = null,
+            IPlayerProgressPersistence persistence = null) : base(data)
         {
+            this.persistence = persistence ?? new SaveDataPlayerProgressPersistence();
             this.inventory = inventory ?? new InventoryModel();
             quickSlotModel = quickSlot ?? new QuickSlotModel();
             oxygen = initialOxygen ?? maxOxygen;
             fuel = maxFuel;
 
             // セーブデータから捕獲した生物を読み込む
-            capturedEntities = SaveDataConverter.LoadCapturedEntities();
+            capturedEntities = this.persistence.LoadCapturedEntities();
         }
 
         public InventoryModel Inventory => inventory;
@@ -116,7 +123,7 @@ namespace Blue.Player
             }
 
             // セーブデータに保存
-            SaveDataConverter.SaveCapturedEntities(capturedEntities);
+            persistence.SaveCapturedEntities(capturedEntities);
         }
     }
 }

--- a/Assets/Scripts/Save/IPlayerProgressPersistence.cs
+++ b/Assets/Scripts/Save/IPlayerProgressPersistence.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Blue.Entity;
+using Blue.Inventory;
+using Blue.UI.QuickSlot;
+
+namespace Blue.Save
+{
+    /// <summary>
+    /// プレイヤー進行データの保存・読み込みを抽象化するインターフェース
+    /// </summary>
+    public interface IPlayerProgressPersistence
+    {
+        InventoryModel LoadPlayerInventory();
+        QuickSlotModel LoadQuickSlot();
+        Dictionary<EntityData, int> LoadCapturedEntities();
+
+        void SavePlayerInventory(InventoryModel inventory);
+        void SaveQuickSlot(QuickSlotModel quickSlot);
+        void SaveCapturedEntities(Dictionary<EntityData, int> capturedEntities);
+    }
+}

--- a/Assets/Scripts/Save/SaveDataPlayerProgressPersistence.cs
+++ b/Assets/Scripts/Save/SaveDataPlayerProgressPersistence.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Blue.Entity;
+using Blue.Inventory;
+using Blue.UI.QuickSlot;
+
+namespace Blue.Save
+{
+    /// <summary>
+    /// SaveDataConverterを利用したプレイヤー進行データ永続化
+    /// </summary>
+    public class SaveDataPlayerProgressPersistence : IPlayerProgressPersistence
+    {
+        public InventoryModel LoadPlayerInventory()
+        {
+            return SaveDataConverter.LoadPlayerInventory();
+        }
+
+        public QuickSlotModel LoadQuickSlot()
+        {
+            return SaveDataConverter.LoadQuickSlot();
+        }
+
+        public Dictionary<EntityData, int> LoadCapturedEntities()
+        {
+            return SaveDataConverter.LoadCapturedEntities();
+        }
+
+        public void SavePlayerInventory(InventoryModel inventory)
+        {
+            SaveDataConverter.SavePlayerInventory(inventory);
+        }
+
+        public void SaveQuickSlot(QuickSlotModel quickSlot)
+        {
+            SaveDataConverter.SaveQuickSlot(quickSlot);
+        }
+
+        public void SaveCapturedEntities(Dictionary<EntityData, int> capturedEntities)
+        {
+            SaveDataConverter.SaveCapturedEntities(capturedEntities);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Decouple player progress persistence from the static `SaveDataConverter` to allow alternative persistence implementations and easier testing.
- Centralize save/load calls for inventory, quickslot, and captured entities behind an interface to reduce duplication and improve extensibility.

### Description
- Added `IPlayerProgressPersistence` interface to abstract loading and saving of `InventoryModel`, `QuickSlotModel`, and captured entities.
- Implemented `SaveDataPlayerProgressPersistence` which delegates to `SaveDataConverter` and implements `IPlayerProgressPersistence`.
- Updated `PlayerController` to hold an `IPlayerProgressPersistence` instance and use it to load/save inventory and quickslot, and to pass it into `PlayerModel` (initialized to `SaveDataPlayerProgressPersistence` by default). 
- Updated `PlayerModel` to accept an optional `IPlayerProgressPersistence` dependency, use it for loading `capturedEntities`, and save captured entities via the injected persistence.

### Testing
- Ran the project's automated unit and playmode test suites after the change, and all tests passed.