### PR TITLE
GameEventControllerのシステム直結をRuntimeBridge経由に分離

### DIFF
--- a/Assets/Scripts/Game/GameEventController.cs
+++ b/Assets/Scripts/Game/GameEventController.cs
@@ -1,26 +1,22 @@
 using UnityEngine;
 using System.Collections.Generic;
 using UnityEngine.Playables;
-using Blue.UI;
-using Blue.Input;
 using Blue.Game;
 using UnityEngine.Timeline;
-using Blue.UI.Screen;
-using Blue.Entity;
-using Blue.Player;
-using Blue.Audio;
 
 public class GameEventController : MonoBehaviour
 {
     [SerializeField] private List<GameEventData> eventList;
     [SerializeField] private PlayableDirector director;
-    [SerializeField] private MecaSharkController shark;
+    [SerializeField] private GameEventRuntimeBridge runtimeBridge;
 
     private GameEventData currentEvent;
     private int dialogueIndex = 0;
     private Dictionary<EventID, GameEventData> eventDict;
     
     public static GameEventController Instance { get; private set; }
+
+    private IGameEventRuntime Runtime => runtimeBridge;
 
     private void Awake()
     {
@@ -31,6 +27,11 @@ public class GameEventController : MonoBehaviour
         }
 
         Instance = this;
+
+        if (runtimeBridge == null)
+        {
+            Debug.LogError("GameEventRuntimeBridge is not assigned.");
+        }
 
         eventDict = new Dictionary<EventID, GameEventData>();
         foreach (GameEventData data in eventList)
@@ -62,51 +63,51 @@ public class GameEventController : MonoBehaviour
         }
 
         string message = currentEvent.DialogueLines[dialogueIndex].text;
-        SubtitleUIController.Instance.ShowMessage(message);
+        Runtime.ShowSubtitle(message);
 
         dialogueIndex++;
     }
 
     public void ForwardIngame()
     {
-        PlayerController.Instance.ForwardIngame();
+        Runtime.ForwardIngame();
     }
 
     public void ForwardMovie()
     {
-        PlayerController.Instance.ForwardMovie();
+        Runtime.ForwardMovie();
     }
 
     public void ShallowSeaBGM()
     {
-        SoundController.Instance.PlayBGM(BGMType.ShallowSea);
+        Runtime.PlayShallowSeaBGM();
     }
 
     public void EmergencyMessage()
     {
-        SoundController.Instance.StopBGM(0.5f);
-        MessageView.Instance.ShowMessage(new MessageData("周囲に大型の動態反応を検知。危険度：<color=red>高</color>"), 5.0f);
+        Runtime.StopBGM(0.5f);
+        Runtime.ShowMessage("周囲に大型の動態反応を検知。危険度：<color=red>高</color>", 5.0f);
     }
 
     public void BattleStart()
     {
-        shark.StartBattle();
-        SoundController.Instance.PlayBGM(BGMType.MecaShark);
-        MessageView.Instance.ShowMessage(new MessageData("ME-G4L0の敵対反応を検知。速やかな対応を推奨"), 8.0f);
+        Runtime.StartMecaSharkBattle();
+        Runtime.PlayMecaSharkBGM();
+        Runtime.ShowMessage("ME-G4L0の敵対反応を検知。速やかな対応を推奨", 8.0f);
     }
 
     public void FoundEMP()
     {
-        MessageView.Instance.ShowMessage(new MessageData("付近にEMP装置を検知。ME-G4L0に対し有効"), 15.0f);
+        Runtime.ShowMessage("付近にEMP装置を検知。ME-G4L0に対し有効", 15.0f);
     }
 
     public void ForwardAquariumScene()
     {
-        SoundController.Instance.StopEnvironmentSound();
-        SoundController.Instance.PlayBGM(BGMType.ShallowSea);
+        Runtime.StopEnvironmentSound();
+        Runtime.PlayShallowSeaBGM();
         ForwardIngame();
         EndEvent();
-        SceneLoader.LoadScene("Aquarium");
+        Runtime.LoadScene("Aquarium");
     }
 
     public void EndEvent()

--- a/Assets/Scripts/Game/GameEventRuntimeBridge.cs
+++ b/Assets/Scripts/Game/GameEventRuntimeBridge.cs
@@ -1,0 +1,72 @@
+using Blue.Audio;
+using Blue.Entity;
+using Blue.Player;
+using Blue.UI;
+using UnityEngine;
+
+namespace Blue.Game
+{
+    /// <summary>
+    /// GameEvent用の各システム橋渡し実装
+    /// </summary>
+    public class GameEventRuntimeBridge : MonoBehaviour, IGameEventRuntime
+    {
+        [SerializeField] private MecaSharkController shark;
+
+        public void ForwardIngame()
+        {
+            PlayerController.Instance.ForwardIngame();
+        }
+
+        public void ForwardMovie()
+        {
+            PlayerController.Instance.ForwardMovie();
+        }
+
+        public void PlayShallowSeaBGM()
+        {
+            SoundController.Instance.PlayBGM(BGMType.ShallowSea);
+        }
+
+        public void PlayMecaSharkBGM()
+        {
+            SoundController.Instance.PlayBGM(BGMType.MecaShark);
+        }
+
+        public void StopBGM(float fadeTime)
+        {
+            SoundController.Instance.StopBGM(fadeTime);
+        }
+
+        public void StopEnvironmentSound()
+        {
+            SoundController.Instance.StopEnvironmentSound();
+        }
+
+        public void ShowSubtitle(string message)
+        {
+            SubtitleUIController.Instance.ShowMessage(message);
+        }
+
+        public void ShowMessage(string message, float duration)
+        {
+            MessageView.Instance.ShowMessage(new MessageData(message), duration);
+        }
+
+        public void StartMecaSharkBattle()
+        {
+            if (shark == null)
+            {
+                Debug.LogWarning("MecaSharkController is not assigned.");
+                return;
+            }
+
+            shark.StartBattle();
+        }
+
+        public void LoadScene(string sceneName)
+        {
+            SceneLoader.LoadScene(sceneName);
+        }
+    }
+}

--- a/Assets/Scripts/Game/IGameEventRuntime.cs
+++ b/Assets/Scripts/Game/IGameEventRuntime.cs
@@ -1,0 +1,19 @@
+namespace Blue.Game
+{
+    /// <summary>
+    /// GameEventControllerが必要とするランタイム操作を抽象化
+    /// </summary>
+    public interface IGameEventRuntime
+    {
+        void ForwardIngame();
+        void ForwardMovie();
+        void PlayShallowSeaBGM();
+        void PlayMecaSharkBGM();
+        void StopBGM(float fadeTime);
+        void StopEnvironmentSound();
+        void ShowSubtitle(string message);
+        void ShowMessage(string message, float duration);
+        void StartMecaSharkBattle();
+        void LoadScene(string sceneName);
+    }
+}

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -56,6 +56,7 @@ namespace Blue.Player
         private int oxygenDecreaseAmount = 1;
         private bool fuelDepleted = false;
         private float fuelDepletedTimer = 0f;
+        private IPlayerProgressPersistence persistence;
 
         public InventoryModel Inventory => model.Inventory;
         public QuickSlotModel QuickSlot => model.QuickSlot;
@@ -87,11 +88,12 @@ namespace Blue.Player
             }
             Instance = this;
             inputHandler = new PlayerInputHandler();
+            persistence = new SaveDataPlayerProgressPersistence();
 
             // セーブデータから読み込み
-            InventoryModel playerInventory = SaveDataConverter.LoadPlayerInventory();
-            QuickSlotModel quickSlot = SaveDataConverter.LoadQuickSlot();
-            model = new PlayerModel(data, playerInventory, quickSlot);
+            InventoryModel playerInventory = persistence.LoadPlayerInventory();
+            QuickSlotModel quickSlot = persistence.LoadQuickSlot();
+            model = new PlayerModel(data, playerInventory, quickSlot, persistence: persistence);
 
             model.Status.OnHPChanged += HandleHPChanged;
             model.OnOxygenChanged += HandleOxygenChanged;
@@ -538,12 +540,12 @@ namespace Blue.Player
 
         private void OnInventoryChanged()
         {
-            SaveDataConverter.SavePlayerInventory(Inventory);
+            persistence.SavePlayerInventory(Inventory);
         }
 
         private void OnQuickSlotChanged()
         {
-            SaveDataConverter.SaveQuickSlot(QuickSlot);
+            persistence.SaveQuickSlot(QuickSlot);
         }
     }
 }

--- a/Assets/Scripts/Player/PlayerModel.cs
+++ b/Assets/Scripts/Player/PlayerModel.cs
@@ -13,21 +13,28 @@ namespace Blue.Player
         private InventoryModel inventory = new InventoryModel();
         private Dictionary<EntityData, int> capturedEntities = new Dictionary<EntityData, int>();
         private QuickSlotModel quickSlotModel;
+        private IPlayerProgressPersistence persistence;
         private int maxOxygen = 100;
         private int oxygen;
         private float maxFuel = 100f;
         private float fuel;
         private float depth;
 
-        public PlayerModel(EntityData data, InventoryModel inventory = null, QuickSlotModel quickSlot = null, int? initialOxygen = null) : base(data)
+        public PlayerModel(
+            EntityData data,
+            InventoryModel inventory = null,
+            QuickSlotModel quickSlot = null,
+            int? initialOxygen = null,
+            IPlayerProgressPersistence persistence = null) : base(data)
         {
+            this.persistence = persistence ?? new SaveDataPlayerProgressPersistence();
             this.inventory = inventory ?? new InventoryModel();
             quickSlotModel = quickSlot ?? new QuickSlotModel();
             oxygen = initialOxygen ?? maxOxygen;
             fuel = maxFuel;
 
             // セーブデータから捕獲した生物を読み込む
-            capturedEntities = SaveDataConverter.LoadCapturedEntities();
+            capturedEntities = this.persistence.LoadCapturedEntities();
         }
 
         public InventoryModel Inventory => inventory;
@@ -116,7 +123,7 @@ namespace Blue.Player
             }
 
             // セーブデータに保存
-            SaveDataConverter.SaveCapturedEntities(capturedEntities);
+            persistence.SaveCapturedEntities(capturedEntities);
         }
     }
 }

--- a/Assets/Scripts/Save/IPlayerProgressPersistence.cs
+++ b/Assets/Scripts/Save/IPlayerProgressPersistence.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Blue.Entity;
+using Blue.Inventory;
+using Blue.UI.QuickSlot;
+
+namespace Blue.Save
+{
+    /// <summary>
+    /// プレイヤー進行データの保存・読み込みを抽象化するインターフェース
+    /// </summary>
+    public interface IPlayerProgressPersistence
+    {
+        InventoryModel LoadPlayerInventory();
+        QuickSlotModel LoadQuickSlot();
+        Dictionary<EntityData, int> LoadCapturedEntities();
+
+        void SavePlayerInventory(InventoryModel inventory);
+        void SaveQuickSlot(QuickSlotModel quickSlot);
+        void SaveCapturedEntities(Dictionary<EntityData, int> capturedEntities);
+    }
+}

--- a/Assets/Scripts/Save/SaveDataPlayerProgressPersistence.cs
+++ b/Assets/Scripts/Save/SaveDataPlayerProgressPersistence.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using Blue.Entity;
+using Blue.Inventory;
+using Blue.UI.QuickSlot;
+
+namespace Blue.Save
+{
+    /// <summary>
+    /// SaveDataConverterを利用したプレイヤー進行データ永続化
+    /// </summary>
+    public class SaveDataPlayerProgressPersistence : IPlayerProgressPersistence
+    {
+        public InventoryModel LoadPlayerInventory()
+        {
+            return SaveDataConverter.LoadPlayerInventory();
+        }
+
+        public QuickSlotModel LoadQuickSlot()
+        {
+            return SaveDataConverter.LoadQuickSlot();
+        }
+
+        public Dictionary<EntityData, int> LoadCapturedEntities()
+        {
+            return SaveDataConverter.LoadCapturedEntities();
+        }
+
+        public void SavePlayerInventory(InventoryModel inventory)
+        {
+            SaveDataConverter.SavePlayerInventory(inventory);
+        }
+
+        public void SaveQuickSlot(QuickSlotModel quickSlot)
+        {
+            SaveDataConverter.SaveQuickSlot(quickSlot);
+        }
+
+        public void SaveCapturedEntities(Dictionary<EntityData, int> capturedEntities)
+        {
+            SaveDataConverter.SaveCapturedEntities(capturedEntities);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Decouple `GameEventController` from direct calls to global singletons to improve modularity and testability.
- Provide an abstraction for player progress persistence to allow swapping or mocking save implementations.
- Centralize game-event runtime operations (audio, UI, scene, player control, enemy start) behind a single bridge to simplify event code.

### Description
- Added `IGameEventRuntime` interface to define the runtime operations used by `GameEventController` and implemented it with `GameEventRuntimeBridge` which forwards calls to existing systems like `SoundController`, `SubtitleUIController`, `MessageView`, `SceneLoader`, and `PlayerController`.
- Reworked `GameEventController` to use a serialized `GameEventRuntimeBridge` (via `IGameEventRuntime`) and replaced direct static calls with calls to the runtime interface, adding a null check with an error log on `Awake`.
- Introduced `IPlayerProgressPersistence` and a concrete `SaveDataPlayerProgressPersistence` that wrap existing `SaveDataConverter` logic, and updated `PlayerController` and `PlayerModel` to use the persistence abstraction for loading/saving inventory, quick slots, and captured entities.
- Minor safety/logging improvements such as warning when `MecaSharkController` is not assigned and preserving existing behavior through the bridge implementation.

### Testing
- Performed Unity Editor compilation to validate references and build-time errors, and the project compiled successfully.
- Ran the project's automated unit tests, and all tests passed successfully.