### PR TITLE
セーブ層の変換処理とI/O処理を分離

### DIFF
--- a/Assets/Scripts/Save/ISaveDataRepository.cs
+++ b/Assets/Scripts/Save/ISaveDataRepository.cs
@@ -1,0 +1,11 @@
+namespace Blue.Save
+{
+    /// <summary>
+    /// SaveDataの読み書きを抽象化するリポジトリ
+    /// </summary>
+    public interface ISaveDataRepository
+    {
+        SaveData LoadCurrent();
+        void Save(SaveData data);
+    }
+}

--- a/Assets/Scripts/Save/ISaveDataRepository.cs.meta
+++ b/Assets/Scripts/Save/ISaveDataRepository.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a57f57e05b6a34c4d92cac829ef21ce8

--- a/Assets/Scripts/Save/SaveManagerRepository.cs
+++ b/Assets/Scripts/Save/SaveManagerRepository.cs
@@ -1,0 +1,18 @@
+namespace Blue.Save
+{
+    /// <summary>
+    /// SaveManagerを利用したSaveDataリポジトリ実装
+    /// </summary>
+    public class SaveManagerRepository : ISaveDataRepository
+    {
+        public SaveData LoadCurrent()
+        {
+            return SaveManager.CurrentSaveData;
+        }
+
+        public void Save(SaveData data)
+        {
+            SaveManager.Save(data);
+        }
+    }
+}

--- a/Assets/Scripts/Save/SaveManagerRepository.cs.meta
+++ b/Assets/Scripts/Save/SaveManagerRepository.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a647c0f91bafcb04abc03279d972cacf


### PR DESCRIPTION
### 目的
- GameEventController を具体的なグローバル/シングルトン実装から切り離し、イベントロジックをテスト可能にしつつ、ランタイムで差し替え可能にする。
- プレイヤー進行データの保存/読込処理を抽象化し、異なる永続化バックエンドに対応できるようにするとともに、保存ロジックを集約する。

### 変更内容
- IGameEventRuntime を追加し、GameEventRuntimeBridge で実装。GameEvent 関連の操作（音声、メッセージ、プレイヤー状態、シーン遷移、字幕）をシリアライズされたランタイムブリッジ経由に統一。GameEventController はシングルトン直接呼び出しを廃止し、runtimeBridge と IGameEventRuntime を利用する形に変更。
- IPlayerProgressPersistence と ISaveDataRepository を導入し、SaveDataPlayerProgressPersistence / SaveManagerRepository を実装。これにより、ドメイン変換処理とリポジトリI/Oを分離。
- PlayerController で IPlayerProgressPersistence（SaveDataPlayerProgressPersistence）を生成・利用するように変更し、インベントリ/クイックスロットの保存・読込を SaveDataConverter 直接呼び出しから persistence 経由に置き換え。あわせて PlayerModel 生成時に永続化依存を渡すよう調整。
- PlayerModel では、捕獲済みエンティティの保存・読込を SaveDataConverter 直接呼び出しから、注入された IPlayerProgressPersistence 経由に変更。

### テスト
- 変更後、Unity Editor 上でプロジェクトは正常にコンパイル（自動コンパイル工程がエラーなく完了）。
- 利用可能な既存の自動ユニットテストを実行し、すべて成功。