### PR TITLE
ProceduralBoneChain の不具合修正と、追従のバネ・ダンパ化

### DIFF
--- a/Assets/Prefab/Entity/Anomalocaris.prefab
+++ b/Assets/Prefab/Entity/Anomalocaris.prefab
@@ -103,19 +103,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Blue.Entity.Common.ProceduralBoneChain
   segments:
   - bone: {fileID: 7156845418751669616}
-    damping: 0.15
+    lagTime: 0.05
   - bone: {fileID: 5103613875272554003}
-    damping: 0.2
+    lagTime: 0.02373
   - bone: {fileID: 7607006317879913028}
-    damping: 0.25
+    lagTime: 0.03578
   - bone: {fileID: 970361165541459087}
-    damping: 0.3
+    lagTime: 0.05593
   - bone: {fileID: 1700640384469906881}
-    damping: 0.35
+    lagTime: 0.09932
   - bone: {fileID: 1402925478529815242}
-    damping: 0.4
-  rotationSpeed: 35
-  dampingFalloff: 0.5
+    lagTime: 0.2712
+  lagFalloff: 0
   useAnimatorRotation: 0
   constrainBoneLength: 1
   maxBendAngle: 45

--- a/Assets/Prefab/Entity/BlackDragon.prefab
+++ b/Assets/Prefab/Entity/BlackDragon.prefab
@@ -197,21 +197,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Blue.Entity.Common.ProceduralBoneChain
   segments:
   - bone: {fileID: 3929120841435602169}
-    damping: 0.1
+    lagTime: 0.05
   - bone: {fileID: 1817236086887917029}
-    damping: 0.15
+    lagTime: 0.04581
   - bone: {fileID: 4382964312780233214}
-    damping: 0.2
+    lagTime: 0.06645
   - bone: {fileID: 8114899815349350858}
-    damping: 0.25
+    lagTime: 0.09618
   - bone: {fileID: 7222944236265420805}
-    damping: 0.3
+    lagTime: 0.146
   - bone: {fileID: 25441706838686137}
-    damping: 0.35
+    lagTime: 0.2509
   - bone: {fileID: 5806269647808990314}
-    damping: 0.4
-  rotationSpeed: 15
-  dampingFalloff: 0.5
+    lagTime: 0.6327
+  lagFalloff: 0
   useAnimatorRotation: 1
   constrainBoneLength: 1
   maxBendAngle: 60

--- a/Assets/Prefab/Entity/FrilledShark.prefab
+++ b/Assets/Prefab/Entity/FrilledShark.prefab
@@ -254,17 +254,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::Blue.Entity.Common.ProceduralBoneChain
   segments:
   - bone: {fileID: 4637777429877914611}
-    damping: 0.1
+    lagTime: 0.05
   - bone: {fileID: 6770706540928511202}
-    damping: 0.15
+    lagTime: 0.1549
   - bone: {fileID: 9177907062376214764}
-    damping: 0.2
+    lagTime: 0.2505
   - bone: {fileID: 8273132938453814594}
-    damping: 0.25
+    lagTime: 0.4255
   - bone: {fileID: 8664379918331621826}
-    damping: 0.3
-  rotationSpeed: 5
-  dampingFalloff: 0.5
+    lagTime: 0.8963
+  lagFalloff: 0
   constrainBoneLength: 1
   maxBendAngle: 45
   branches: []

--- a/Assets/Scripts/Entity/Common/BoneChainBranch.cs
+++ b/Assets/Scripts/Entity/Common/BoneChainBranch.cs
@@ -8,36 +8,38 @@ namespace Blue.Entity.Common
     /// メインチェーンの特定セグメントに追従する
     /// </summary>
     // メインチェーンと違い、こちらは Animator の姿勢ではなく初期姿勢を基準にする。
-    // ヒレのようにアニメーションを持たないボーンでも、慣性で倒れた分が
-    // 初期姿勢へ戻ってくるようにするため。
+    // ヒレのようにアニメーションを持たないボーンでも、倒れた分が初期姿勢へ戻ってくるようにするため。
     [Serializable]
     public class BoneChainBranch
     {
         [Header("Branch Settings")]
         [SerializeField] private string branchName;
 
-        [Tooltip("根元から末端への順序で設定")]
+        [Tooltip("根元から末端への順序で設定。末端は向きの基準にしか使わないので最低2本必要")]
         [SerializeField] private Transform[] branchBones;
 
         [Header("Follow Settings")]
         [Tooltip("追従する親セグメントのインデックス（0始まり）")]
         [SerializeField] private int parentSegmentIndex;
 
-        [Tooltip("親の移動速度に対して倒れる量")]
-        [SerializeField, Range(0f, 1f)] private float followStrength = 0.5f;
+        [Tooltip("追従の遅れ時間（秒）")]
+        [SerializeField, Range(0.01f, 1f)] private float lagTime = 0.12f;
 
-        [Tooltip("追従の遅れ（0=即座に追従、1に近いほど遅い）")]
-        [SerializeField, Range(0f, 0.99f)] private float damping = 0.2f;
+        [Tooltip("行き過ぎて揺れ戻る量（0=行き過ぎなし、大きいほど揺れが残る）")]
+        [SerializeField, Range(0f, 0.9f)] private float overshoot = 0.6f;
+
+        [Tooltip("進行方向と逆に寝かせる量。親の移動速度に比例するので泳ぐほど後ろへ倒れる")]
+        [SerializeField, Range(0f, 1f)] private float followStrength = 0.2f;
 
         [SerializeField] private bool enabled = true;
 
-        private const float MaxDamping = 0.999f;
         private const float MinDirectionSqr = 0.0001f;
 
         // ランタイムキャッシュ
         private Quaternion[] initialLocalRotations;
         private Vector3[] childLocalDirections;
         private Quaternion[] currentRotations;
+        private Vector3[] angularVelocities;
         private bool isInitialized;
 
         // プロパティ
@@ -45,7 +47,7 @@ namespace Blue.Entity.Common
         public Transform[] BranchBones => branchBones;
         public int ParentSegmentIndex => parentSegmentIndex;
         public float FollowStrength => followStrength;
-        public float Damping => damping;
+        public float LagTime => lagTime;
         public bool Enabled { get => enabled; set => enabled = value; }
         public bool IsInitialized => isInitialized;
 
@@ -54,15 +56,16 @@ namespace Blue.Entity.Common
         /// </summary>
         public void Initialize()
         {
-            if (branchBones == null || branchBones.Length == 0)
+            if (branchBones == null || branchBones.Length < 2)
             {
-                Debug.LogWarning($"[BoneChainBranch] {branchName}: No branch bones defined.");
+                Debug.LogWarning($"[BoneChainBranch] {branchName}: 分岐には末端を含めて2本以上のボーンが必要です。");
                 return;
             }
 
             initialLocalRotations = new Quaternion[branchBones.Length];
             childLocalDirections = new Vector3[branchBones.Length];
             currentRotations = new Quaternion[branchBones.Length];
+            angularVelocities = new Vector3[branchBones.Length];
 
             for (int i = 0; i < branchBones.Length; i++)
             {
@@ -90,17 +93,13 @@ namespace Blue.Entity.Common
         /// </summary>
         /// <param name="parentVelocity">親セグメントの速度</param>
         /// <param name="deltaTime">デルタタイム</param>
-        /// <param name="followSpeed">追従速度（メインチェーンと共通）</param>
-        public void UpdateBranch(Vector3 parentVelocity, float deltaTime, float followSpeed)
+        public void UpdateBranch(Vector3 parentVelocity, float deltaTime)
         {
             if (!enabled || !isInitialized || branchBones == null) return;
             if (deltaTime <= 0f) return;
 
-            // 親の移動と逆向きに倒れる
+            // 親の移動と逆向きに寝かせる
             Vector3 inertia = -parentVelocity * followStrength;
-
-            float t = 1f - Mathf.Pow(Mathf.Clamp(damping, 0f, MaxDamping), deltaTime * followSpeed);
-            t = Mathf.Clamp01(t);
 
             // 末端ボーンは子を持たないので回転させても形状が変わらない
             for (int i = 0; i < branchBones.Length - 1; i++)
@@ -108,7 +107,7 @@ namespace Blue.Entity.Common
                 Transform bone = branchBones[i];
                 if (bone == null || branchBones[i + 1] == null) continue;
 
-                // 親の現在姿勢のうえで初期姿勢を取ったときの回転・方向
+                // 親の現在姿勢のうえで初期姿勢を取ったときの回転と、その向き
                 Quaternion parentRotation = bone.parent != null ? bone.parent.rotation : Quaternion.identity;
                 Quaternion restRotation = parentRotation * initialLocalRotations[i];
                 Vector3 restDirection = restRotation * childLocalDirections[i];
@@ -120,8 +119,12 @@ namespace Blue.Entity.Common
                     ? Quaternion.FromToRotation(restDirection, targetDirection.normalized) * restRotation
                     : restRotation;
 
-                bone.rotation = Quaternion.Slerp(currentRotations[i], targetRotation, t);
-                currentRotations[i] = bone.rotation;
+                Vector3 angularVelocity = angularVelocities[i];
+                currentRotations[i] = BoneChainSpring.Step(
+                    currentRotations[i], targetRotation, ref angularVelocity, lagTime, overshoot, deltaTime);
+                angularVelocities[i] = angularVelocity;
+
+                bone.rotation = currentRotations[i];
             }
         }
 
@@ -138,6 +141,7 @@ namespace Blue.Entity.Common
 
                 branchBones[i].localRotation = initialLocalRotations[i];
                 currentRotations[i] = branchBones[i].rotation;
+                angularVelocities[i] = Vector3.zero;
             }
         }
     }

--- a/Assets/Scripts/Entity/Common/BoneChainBranch.cs
+++ b/Assets/Scripts/Entity/Common/BoneChainBranch.cs
@@ -7,30 +7,41 @@ namespace Blue.Entity.Common
     /// 分岐ボーン（ヒレなど）を制御するクラス
     /// メインチェーンの特定セグメントに追従する
     /// </summary>
+    // メインチェーンと違い、こちらは Animator の姿勢ではなく初期姿勢を基準にする。
+    // ヒレのようにアニメーションを持たないボーンでも、慣性で倒れた分が
+    // 初期姿勢へ戻ってくるようにするため。
     [Serializable]
     public class BoneChainBranch
     {
         [Header("Branch Settings")]
         [SerializeField] private string branchName;
-        [SerializeField] private Transform branchRoot;
+
+        [Tooltip("根元から末端への順序で設定")]
         [SerializeField] private Transform[] branchBones;
 
         [Header("Follow Settings")]
         [Tooltip("追従する親セグメントのインデックス（0始まり）")]
         [SerializeField] private int parentSegmentIndex;
+
+        [Tooltip("親の移動速度に対して倒れる量")]
         [SerializeField, Range(0f, 1f)] private float followStrength = 0.5f;
-        [SerializeField, Range(0f, 1f)] private float damping = 0.2f;
+
+        [Tooltip("追従の遅れ（0=即座に追従、1に近いほど遅い）")]
+        [SerializeField, Range(0f, 0.99f)] private float damping = 0.2f;
+
         [SerializeField] private bool enabled = true;
 
+        private const float MaxDamping = 0.999f;
+        private const float MinDirectionSqr = 0.0001f;
+
         // ランタイムキャッシュ
-        private float[] boneLengths;
         private Quaternion[] initialLocalRotations;
-        private Vector3[] previousPositions;
+        private Vector3[] childLocalDirections;
+        private Quaternion[] currentRotations;
         private bool isInitialized;
 
         // プロパティ
         public string BranchName => branchName;
-        public Transform BranchRoot => branchRoot;
         public Transform[] BranchBones => branchBones;
         public int ParentSegmentIndex => parentSegmentIndex;
         public float FollowStrength => followStrength;
@@ -49,24 +60,25 @@ namespace Blue.Entity.Common
                 return;
             }
 
-            boneLengths = new float[branchBones.Length];
             initialLocalRotations = new Quaternion[branchBones.Length];
-            previousPositions = new Vector3[branchBones.Length];
+            childLocalDirections = new Vector3[branchBones.Length];
+            currentRotations = new Quaternion[branchBones.Length];
 
             for (int i = 0; i < branchBones.Length; i++)
             {
                 if (branchBones[i] == null) continue;
 
                 initialLocalRotations[i] = branchBones[i].localRotation;
-                previousPositions[i] = branchBones[i].position;
+                currentRotations[i] = branchBones[i].rotation;
 
-                // ボーン長を計算
+                // 次のボーンへ向かう方向を、自分のローカル空間で保持する
                 if (i < branchBones.Length - 1 && branchBones[i + 1] != null)
                 {
-                    boneLengths[i] = Vector3.Distance(
-                        branchBones[i].position,
-                        branchBones[i + 1].position
-                    );
+                    Vector3 toChild = branchBones[i + 1].position - branchBones[i].position;
+
+                    childLocalDirections[i] = toChild.sqrMagnitude > MinDirectionSqr
+                        ? branchBones[i].InverseTransformDirection(toChild.normalized)
+                        : Vector3.forward;
                 }
             }
 
@@ -78,50 +90,38 @@ namespace Blue.Entity.Common
         /// </summary>
         /// <param name="parentVelocity">親セグメントの速度</param>
         /// <param name="deltaTime">デルタタイム</param>
-        public void UpdateBranch(Vector3 parentVelocity, float deltaTime)
+        /// <param name="followSpeed">追従速度（メインチェーンと共通）</param>
+        public void UpdateBranch(Vector3 parentVelocity, float deltaTime, float followSpeed)
         {
             if (!enabled || !isInitialized || branchBones == null) return;
+            if (deltaTime <= 0f) return;
 
-            for (int i = 0; i < branchBones.Length; i++)
+            // 親の移動と逆向きに倒れる
+            Vector3 inertia = -parentVelocity * followStrength;
+
+            float t = 1f - Mathf.Pow(Mathf.Clamp(damping, 0f, MaxDamping), deltaTime * followSpeed);
+            t = Mathf.Clamp01(t);
+
+            // 末端ボーンは子を持たないので回転させても形状が変わらない
+            for (int i = 0; i < branchBones.Length - 1; i++)
             {
-                if (branchBones[i] == null) continue;
+                Transform bone = branchBones[i];
+                if (bone == null || branchBones[i + 1] == null) continue;
 
-                // 親の動きに対する遅延追従（速度の逆方向に少し遅れる）
-                Vector3 inertiaOffset = -parentVelocity * followStrength * deltaTime;
+                // 親の現在姿勢のうえで初期姿勢を取ったときの回転・方向
+                Quaternion parentRotation = bone.parent != null ? bone.parent.rotation : Quaternion.identity;
+                Quaternion restRotation = parentRotation * initialLocalRotations[i];
+                Vector3 restDirection = restRotation * childLocalDirections[i];
 
-                // 目標位置を計算
-                Vector3 targetPos = branchBones[i].position + inertiaOffset;
+                // 慣性で倒した先へ、ボーンの軸のとり方に依存しない形で振る
+                Vector3 targetDirection = restDirection + inertia;
 
-                // 回転の計算（前のボーンを向く）
-                if (i > 0 && branchBones[i - 1] != null)
-                {
-                    Vector3 dirToParent = (branchBones[i - 1].position - branchBones[i].position).normalized;
-                    if (dirToParent.sqrMagnitude > 0.001f)
-                    {
-                        Quaternion targetRot = Quaternion.LookRotation(dirToParent);
-                        branchBones[i].rotation = Quaternion.Slerp(
-                            branchBones[i].rotation,
-                            targetRot,
-                            damping
-                        );
-                    }
-                }
+                Quaternion targetRotation = targetDirection.sqrMagnitude > MinDirectionSqr
+                    ? Quaternion.FromToRotation(restDirection, targetDirection.normalized) * restRotation
+                    : restRotation;
 
-                // ボーン長の制約を適用
-                if (i > 0 && branchBones[i - 1] != null && boneLengths[i - 1] > 0f)
-                {
-                    Vector3 parentBonePos = branchBones[i - 1].position;
-                    Vector3 dir = (branchBones[i].position - parentBonePos).normalized;
-
-                    if (dir.sqrMagnitude < 0.001f)
-                    {
-                        dir = -branchBones[i - 1].forward;
-                    }
-
-                    branchBones[i].position = parentBonePos + dir * boneLengths[i - 1];
-                }
-
-                previousPositions[i] = branchBones[i].position;
+                bone.rotation = Quaternion.Slerp(currentRotations[i], targetRotation, t);
+                currentRotations[i] = bone.rotation;
             }
         }
 
@@ -134,10 +134,10 @@ namespace Blue.Entity.Common
 
             for (int i = 0; i < branchBones.Length; i++)
             {
-                if (branchBones[i] != null)
-                {
-                    branchBones[i].localRotation = initialLocalRotations[i];
-                }
+                if (branchBones[i] == null) continue;
+
+                branchBones[i].localRotation = initialLocalRotations[i];
+                currentRotations[i] = branchBones[i].rotation;
             }
         }
     }

--- a/Assets/Scripts/Entity/Common/BoneChainSegment.cs
+++ b/Assets/Scripts/Entity/Common/BoneChainSegment.cs
@@ -14,20 +14,21 @@ namespace Blue.Entity.Common
         [SerializeField] private Transform bone;
 
         [Header("Settings")]
-        [Tooltip("追従の遅れ（0=即座に追従、1=ほぼ追従しない）")]
-        [SerializeField, Range(0f, 0.99f)] private float damping = 0.1f;
+        [Tooltip("追従の遅れ時間（秒）。大きいほど親から遅れて付いてくる")]
+        [SerializeField, Range(0.01f, 1f)] private float lagTime = 0.1f;
 
         // ランタイム用キャッシュ（非シリアライズ）
         private float cachedBoneLength;
         private Quaternion initialLocalRotation;
         private Vector3 previousPosition;
         private Vector3 velocity;
+        private Vector3 angularVelocity;
         private Quaternion currentRotation;
         private bool isInitialized;
 
         // プロパティ
         public Transform Bone => bone;
-        public float Damping => damping;
+        public float LagTime => lagTime;
 
         /// <summary>このボーンから次のボーンまでの距離（末端は0）</summary>
         // 親からの距離ではない。segments[i] の長さを使いたい側は
@@ -39,6 +40,9 @@ namespace Blue.Entity.Common
 
         /// <summary>直近フレームでのワールド移動速度</summary>
         public Vector3 Velocity { get => velocity; set => velocity = value; }
+
+        /// <summary>バネ追従の角速度（ラジアン/秒、回転軸方向）</summary>
+        public Vector3 AngularVelocity { get => angularVelocity; set => angularVelocity = value; }
 
         public Quaternion CurrentRotation { get => currentRotation; set => currentRotation = value; }
         public bool IsInitialized => isInitialized;
@@ -58,6 +62,7 @@ namespace Blue.Entity.Common
             initialLocalRotation = bone.localRotation;
             previousPosition = bone.position;
             velocity = Vector3.zero;
+            angularVelocity = Vector3.zero;
             currentRotation = bone.rotation;
 
             // ボーン長を計算（次のボーンがある場合）
@@ -81,6 +86,7 @@ namespace Blue.Entity.Common
             if (bone != null && isInitialized)
             {
                 bone.localRotation = initialLocalRotation;
+                angularVelocity = Vector3.zero;
                 currentRotation = bone.rotation;
             }
         }

--- a/Assets/Scripts/Entity/Common/BoneChainSegment.cs
+++ b/Assets/Scripts/Entity/Common/BoneChainSegment.cs
@@ -21,15 +21,25 @@ namespace Blue.Entity.Common
         private float cachedBoneLength;
         private Quaternion initialLocalRotation;
         private Vector3 previousPosition;
+        private Vector3 velocity;
         private Quaternion currentRotation;
         private bool isInitialized;
 
         // プロパティ
         public Transform Bone => bone;
         public float Damping => damping;
+
+        /// <summary>このボーンから次のボーンまでの距離（末端は0）</summary>
+        // 親からの距離ではない。segments[i] の長さを使いたい側は
+        // segments[i].BoneLength ではなく segments[i-1].BoneLength を見ること。
         public float BoneLength => cachedBoneLength;
+
         public Quaternion InitialLocalRotation => initialLocalRotation;
         public Vector3 PreviousPosition { get => previousPosition; set => previousPosition = value; }
+
+        /// <summary>直近フレームでのワールド移動速度</summary>
+        public Vector3 Velocity { get => velocity; set => velocity = value; }
+
         public Quaternion CurrentRotation { get => currentRotation; set => currentRotation = value; }
         public bool IsInitialized => isInitialized;
 
@@ -47,6 +57,7 @@ namespace Blue.Entity.Common
 
             initialLocalRotation = bone.localRotation;
             previousPosition = bone.position;
+            velocity = Vector3.zero;
             currentRotation = bone.rotation;
 
             // ボーン長を計算（次のボーンがある場合）

--- a/Assets/Scripts/Entity/Common/BoneChainSpring.cs
+++ b/Assets/Scripts/Entity/Common/BoneChainSpring.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+
+namespace Blue.Entity.Common
+{
+    /// <summary>
+    /// ボーンを目標姿勢へバネ・ダンパで追従させる計算
+    /// </summary>
+    // 一次の指数補間（Slerp）は原理的に目標を行き過ぎないため、揺れ戻りが出ず動きが硬くなる。
+    // 角速度を状態として持つ二次系にすることで、行き過ぎと揺れ戻りを作る。
+    // メインチェーンと分岐で同じ挙動にしたいので、ここに集約している。
+    internal static class BoneChainSpring
+    {
+        /// <summary>遅れ時間の下限（秒）</summary>
+        public const float MinLagTime = 0.01f;
+
+        /// <summary>遅れ時間の上限（秒）。これを超えると事実上停止して見える</summary>
+        public const float MaxLagTime = 1f;
+
+        // zeta を 0 にすると永久に揺れ続けるため下限を設ける
+        private const float MinDampingRatio = 0.1f;
+
+        // 明示積分なので omega * deltaTime が大きいと発散する
+        private const float MaxOmegaStep = 0.5f;
+
+        // これ以下の角速度は回転軸が不定になるので無視する
+        private const float MinAngularStep = 1e-6f;
+
+        /// <summary>
+        /// 現在の姿勢を目標姿勢へ1ステップ近づける
+        /// </summary>
+        /// <param name="current">現在のワールド回転</param>
+        /// <param name="target">目標のワールド回転</param>
+        /// <param name="angularVelocity">角速度の状態。呼び出し側がボーンごとに保持する</param>
+        /// <param name="lagTime">遅れ時間（秒）</param>
+        /// <param name="overshoot">行き過ぎ量（0=臨界減衰、大きいほど揺れが残る）</param>
+        /// <param name="deltaTime">デルタタイム</param>
+        public static Quaternion Step(Quaternion current, Quaternion target, ref Vector3 angularVelocity,
+            float lagTime, float overshoot, float deltaTime)
+        {
+            float clampedLag = Mathf.Clamp(lagTime, MinLagTime, MaxLagTime);
+
+            // omega は固有角振動数、zeta は減衰比
+            float omega = Mathf.Min(1f / clampedLag, MaxOmegaStep / deltaTime);
+            float zeta = Mathf.Max(1f - overshoot, MinDampingRatio);
+
+            // 目標までのズレを回転ベクトル（ラジアン）として取り出す
+            Quaternion difference = Quaternion.Normalize(target * Quaternion.Inverse(current));
+            difference.ToAngleAxis(out float differenceAngle, out Vector3 differenceAxis);
+            if (differenceAngle > 180f)
+            {
+                differenceAngle -= 360f;
+            }
+            Vector3 error = differenceAxis * (differenceAngle * Mathf.Deg2Rad);
+
+            // 準陰的オイラー：速度を先に更新してから積分する
+            angularVelocity += (omega * omega * error - 2f * zeta * omega * angularVelocity) * deltaTime;
+
+            float angularStep = angularVelocity.magnitude * deltaTime;
+
+            return angularStep > MinAngularStep
+                ? Quaternion.AngleAxis(angularStep * Mathf.Rad2Deg, angularVelocity.normalized) * current
+                : current;
+        }
+    }
+}

--- a/Assets/Scripts/Entity/Common/BoneChainSpring.cs
+++ b/Assets/Scripts/Entity/Common/BoneChainSpring.cs
@@ -19,8 +19,11 @@ namespace Blue.Entity.Common
         // zeta を 0 にすると永久に揺れ続けるため下限を設ける
         private const float MinDampingRatio = 0.1f;
 
-        // 明示積分なので omega * deltaTime が大きいと発散する
+        // 1 サブステップあたりに許す omega * 刻み幅。これを超えると明示積分が発散する
         private const float MaxOmegaStep = 0.5f;
+
+        // 分割数の上限。極端に低いフレームレートでは頭打ちになる
+        private const int MaxSubSteps = 8;
 
         // これ以下の角速度は回転軸が不定になるので無視する
         private const float MinAngularStep = 1e-6f;
@@ -40,26 +43,37 @@ namespace Blue.Entity.Common
             float clampedLag = Mathf.Clamp(lagTime, MinLagTime, MaxLagTime);
 
             // omega は固有角振動数、zeta は減衰比
-            float omega = Mathf.Min(1f / clampedLag, MaxOmegaStep / deltaTime);
+            float omega = 1f / clampedLag;
             float zeta = Mathf.Max(1f - overshoot, MinDampingRatio);
 
-            // 目標までのズレを回転ベクトル（ラジアン）として取り出す
-            Quaternion difference = Quaternion.Normalize(target * Quaternion.Inverse(current));
-            difference.ToAngleAxis(out float differenceAngle, out Vector3 differenceAxis);
-            if (differenceAngle > 180f)
+            // 明示積分なので omega * 刻み幅 が大きいと発散する。omega を下げて回避すると
+            // 1 フレームあたりの進み方が固定されてしまい、フレームレートによって追従の
+            // 速さが変わる（lagTime を秒で指定した意味が無くなる）。刻みを分割して積む。
+            int subSteps = Mathf.Clamp(Mathf.CeilToInt(omega * deltaTime / MaxOmegaStep), 1, MaxSubSteps);
+            float subDeltaTime = deltaTime / subSteps;
+
+            for (int i = 0; i < subSteps; i++)
             {
-                differenceAngle -= 360f;
+                // 目標までのズレを回転ベクトル（ラジアン）として取り出す
+                Quaternion difference = Quaternion.Normalize(target * Quaternion.Inverse(current));
+                difference.ToAngleAxis(out float differenceAngle, out Vector3 differenceAxis);
+                if (differenceAngle > 180f)
+                {
+                    differenceAngle -= 360f;
+                }
+                Vector3 error = differenceAxis * (differenceAngle * Mathf.Deg2Rad);
+
+                // 準陰的オイラー：速度を先に更新してから積分する
+                angularVelocity += (omega * omega * error - 2f * zeta * omega * angularVelocity) * subDeltaTime;
+
+                float angularStep = angularVelocity.magnitude * subDeltaTime;
+                if (angularStep > MinAngularStep)
+                {
+                    current = Quaternion.AngleAxis(angularStep * Mathf.Rad2Deg, angularVelocity.normalized) * current;
+                }
             }
-            Vector3 error = differenceAxis * (differenceAngle * Mathf.Deg2Rad);
 
-            // 準陰的オイラー：速度を先に更新してから積分する
-            angularVelocity += (omega * omega * error - 2f * zeta * omega * angularVelocity) * deltaTime;
-
-            float angularStep = angularVelocity.magnitude * deltaTime;
-
-            return angularStep > MinAngularStep
-                ? Quaternion.AngleAxis(angularStep * Mathf.Rad2Deg, angularVelocity.normalized) * current
-                : current;
+            return current;
         }
     }
 }

--- a/Assets/Scripts/Entity/Common/BoneChainSpring.cs.meta
+++ b/Assets/Scripts/Entity/Common/BoneChainSpring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 66e7d16a0881fce438e05cde64009f88

--- a/Assets/Scripts/Entity/Common/ProceduralBoneChain.cs
+++ b/Assets/Scripts/Entity/Common/ProceduralBoneChain.cs
@@ -37,9 +37,13 @@ namespace Blue.Entity.Common
         [SerializeField] private Color debugConstraintColor = Color.yellow;
 
         // ランタイム
+        private const float LengthTolerance = 0.0001f;
+
+        // 1.0 にすると t が 0 になりボーンが完全に停止するため、わずかに手前で止める
+        private const float MaxDamping = 0.999f;
+
         private bool isInitialized = false;
         private Transform headBone;
-        private Vector3 previousHeadPosition;
 
         // プロパティ
         public List<BoneChainSegment> Segments => segments;
@@ -48,6 +52,15 @@ namespace Blue.Entity.Common
         public float RotationSpeed { get => rotationSpeed; set => rotationSpeed = Mathf.Max(1f, value); }
 
         #region Unity Lifecycle
+
+        /// <summary>
+        /// 再有効化時に初期化をやり直す
+        /// </summary>
+        // プール等で使い回した際に前回の姿勢・ボーン長を持ち越さないようにする
+        private void OnEnable()
+        {
+            isInitialized = false;
+        }
 
         /// <summary>
         /// LateUpdateでAnimator更新後にボーンを制御
@@ -65,12 +78,6 @@ namespace Blue.Entity.Common
 
             UpdateBoneChain();
             UpdateBranches();
-
-            // 状態を保存
-            if (headBone != null)
-            {
-                previousHeadPosition = headBone.position;
-            }
         }
 
         #endregion
@@ -85,6 +92,7 @@ namespace Blue.Entity.Common
             if (segments.Count == 0)
             {
                 Debug.LogWarning($"[ProceduralBoneChain] {name}: No segments defined.");
+                isInitialized = true; // 毎フレーム警告を出し続けないようにする
                 return;
             }
 
@@ -99,10 +107,6 @@ namespace Blue.Entity.Common
 
             // 先頭ボーンをキャッシュ
             headBone = segments[0].Bone;
-            if (headBone != null)
-            {
-                previousHeadPosition = headBone.position;
-            }
 
             // 分岐の初期化
             foreach (BoneChainBranch branch in branches)
@@ -127,8 +131,9 @@ namespace Blue.Entity.Common
             float deltaTime = Time.deltaTime;
             if (deltaTime <= 0f) return;
 
-            // 先頭ボーンの回転を保存（先頭は制御しない）
+            // 先頭ボーンの状態を保存（先頭は制御しない）
             segments[0].CurrentRotation = headBone.rotation;
+            segments[0].Velocity = (headBone.position - segments[0].PreviousPosition) / deltaTime;
             segments[0].PreviousPosition = headBone.position;
 
             // 後続のボーンを順番に更新（前から後ろへ）
@@ -155,24 +160,35 @@ namespace Blue.Entity.Common
             Transform bone = segment.Bone;
             Transform parentBone = parent.Bone;
 
+            // チェーン補正を掛ける前の位置から今フレームの速度を求める（分岐が参照する）
+            segment.Velocity = (bone.position - segment.PreviousPosition) / deltaTime;
+
             // === Step 1: 位置の制約（ボーン長を保持） ===
-            if (constrainBoneLength && segment.BoneLength > 0f)
+            // 親からこのボーンまでの距離は parent.BoneLength 側に入っている。
+            // 通常は bone が parentBone の子なので親を回した時点で長さは保たれており、
+            // 位置アニメや階層が繋がっていないボーンを並べた場合だけ補正が要る。
+            float restLength = parent.BoneLength;
+
+            if (constrainBoneLength && restLength > 0f)
             {
-                // 現在の位置から親への方向を取得
-                Vector3 dirFromParent = (bone.position - parentBone.position);
+                Vector3 dirFromParent = bone.position - parentBone.position;
+                float currentLength = dirFromParent.magnitude;
 
-                if (dirFromParent.sqrMagnitude < 0.0001f)
+                if (Mathf.Abs(currentLength - restLength) > LengthTolerance)
                 {
-                    // ほぼ同じ位置の場合、親の後方を使用
-                    dirFromParent = -parentBone.forward;
-                }
-                else
-                {
-                    dirFromParent.Normalize();
-                }
+                    if (currentLength < LengthTolerance)
+                    {
+                        // ほぼ同じ位置の場合、親の後方を使用
+                        dirFromParent = -parentBone.forward;
+                    }
+                    else
+                    {
+                        dirFromParent /= currentLength;
+                    }
 
-                // 親から固定距離の位置に配置
-                bone.position = parentBone.position + dirFromParent * segment.BoneLength;
+                    // 親から固定距離の位置に配置
+                    bone.position = parentBone.position + dirFromParent * restLength;
+                }
             }
 
             // === Step 2: 回転の追従（親の回転に滑らかに追従） ===
@@ -183,15 +199,9 @@ namespace Blue.Entity.Common
             Quaternion localRotation = useAnimatorRotation ? bone.localRotation : segment.InitialLocalRotation;
             Quaternion targetRotation = parentBone.rotation * localRotation;
 
-            // 角度制限の適用
-            if (maxBendAngle < 180f)
-            {
-                targetRotation = ApplyAngleConstraint(targetRotation, parent.CurrentRotation, localRotation);
-            }
-
             // ダンピング計算（シンプルな指数減衰）
             float effectiveDamping = segment.Damping + additionalDamping;
-            effectiveDamping = Mathf.Clamp01(effectiveDamping);
+            effectiveDamping = Mathf.Clamp(effectiveDamping, 0f, MaxDamping);
 
             // t = 1 - damping^(deltaTime * speed) の近似
             float t = 1f - Mathf.Pow(effectiveDamping, deltaTime * rotationSpeed);
@@ -199,6 +209,14 @@ namespace Blue.Entity.Common
 
             // 現在の回転から目標回転へ補間
             Quaternion newRotation = Quaternion.Slerp(segment.CurrentRotation, targetRotation, t);
+
+            // 角度制限の適用
+            // 折れ曲がりは補間の遅れによって生じるので、目標回転ではなく補間結果に掛ける。
+            // 基準は初期ローカル回転。ここに現在のローカル回転を渡すと差分が常に恒等回転になり制限が効かない
+            if (maxBendAngle < 180f)
+            {
+                newRotation = ApplyAngleConstraint(newRotation, parentBone.rotation, segment.InitialLocalRotation);
+            }
 
             bone.rotation = newRotation;
             segment.CurrentRotation = newRotation;
@@ -258,10 +276,9 @@ namespace Blue.Entity.Common
                 BoneChainSegment parentSegment = segments[branch.ParentSegmentIndex];
                 if (parentSegment.Bone == null) continue;
 
-                // 親セグメントの速度を計算
-                Vector3 parentVelocity = (parentSegment.Bone.position - parentSegment.PreviousPosition) / deltaTime;
-
-                branch.UpdateBranch(parentVelocity, deltaTime);
+                // 速度は UpdateSegment 内で PreviousPosition を上書きする前に取ってある。
+                // ここで差分を取り直すと同一フレームの値同士になり常にゼロになる
+                branch.UpdateBranch(parentSegment.Velocity, deltaTime, rotationSpeed);
             }
         }
 
@@ -346,10 +363,14 @@ namespace Blue.Entity.Common
                     BoneChainSegment segment = segments[i];
                     BoneChainSegment parent = segments[i - 1];
 
-                    if (parent.Bone != null && segment.BoneLength > 0f)
-                    {
-                        Gizmos.DrawWireSphere(parent.Bone.position, segment.BoneLength);
-                    }
+                    if (parent.Bone == null || segment.Bone == null) continue;
+
+                    // 再生前は BoneLength が未キャッシュなので現在の距離で代用する
+                    float restLength = parent.BoneLength > 0f
+                        ? parent.BoneLength
+                        : Vector3.Distance(parent.Bone.position, segment.Bone.position);
+
+                    Gizmos.DrawWireSphere(parent.Bone.position, restLength);
                 }
             }
 

--- a/Assets/Scripts/Entity/Common/ProceduralBoneChain.cs
+++ b/Assets/Scripts/Entity/Common/ProceduralBoneChain.cs
@@ -15,11 +15,11 @@ namespace Blue.Entity.Common
         [SerializeField] private List<BoneChainSegment> segments = new List<BoneChainSegment>();
 
         [Header("Follow Settings")]
-        [Tooltip("回転の追従速度（大きいほど速く追従）")]
-        [SerializeField, Range(1f, 50f)] private float rotationSpeed = 15f;
+        [Tooltip("末端に向かうほど遅れを伸ばす倍率（0=セグメント個別の設定のみ）")]
+        [SerializeField, Range(0f, 3f)] private float lagFalloff = 0f;
 
-        [Tooltip("末端に向かうほど遅延を増加させる係数")]
-        [SerializeField, Range(0f, 2f)] private float dampingFalloff = 0.5f;
+        [Tooltip("行き過ぎて揺れ戻る量（0=行き過ぎなし、大きいほど揺れが残る）")]
+        [SerializeField, Range(0f, 0.9f)] private float overshoot = 0f;
 
         [Tooltip("Animatorアニメーションを使用するか")]
         [SerializeField] private bool useAnimatorRotation = true;
@@ -39,9 +39,6 @@ namespace Blue.Entity.Common
         // ランタイム
         private const float LengthTolerance = 0.0001f;
 
-        // 1.0 にすると t が 0 になりボーンが完全に停止するため、わずかに手前で止める
-        private const float MaxDamping = 0.999f;
-
         private bool isInitialized = false;
         private Transform headBone;
 
@@ -49,7 +46,6 @@ namespace Blue.Entity.Common
         public List<BoneChainSegment> Segments => segments;
         public List<BoneChainBranch> Branches => branches;
         public bool IsInitialized => isInitialized;
-        public float RotationSpeed { get => rotationSpeed; set => rotationSpeed = Mathf.Max(1f, value); }
 
         #region Unity Lifecycle
 
@@ -144,18 +140,17 @@ namespace Blue.Entity.Common
 
                 if (currentSegment.Bone == null || parentSegment.Bone == null) continue;
 
-                // 末端に向かうほどダンピングを増加
+                // 末端に向かうほど遅れを大きくする
                 float chainProgress = (float)i / (segments.Count - 1);
-                float additionalDamping = chainProgress * dampingFalloff;
 
-                UpdateSegment(currentSegment, parentSegment, deltaTime, additionalDamping);
+                UpdateSegment(currentSegment, parentSegment, deltaTime, chainProgress);
             }
         }
 
         /// <summary>
         /// 個別セグメントの更新
         /// </summary>
-        private void UpdateSegment(BoneChainSegment segment, BoneChainSegment parent, float deltaTime, float additionalDamping)
+        private void UpdateSegment(BoneChainSegment segment, BoneChainSegment parent, float deltaTime, float chainProgress)
         {
             Transform bone = segment.Bone;
             Transform parentBone = parent.Bone;
@@ -199,16 +194,13 @@ namespace Blue.Entity.Common
             Quaternion localRotation = useAnimatorRotation ? bone.localRotation : segment.InitialLocalRotation;
             Quaternion targetRotation = parentBone.rotation * localRotation;
 
-            // ダンピング計算（シンプルな指数減衰）
-            float effectiveDamping = segment.Damping + additionalDamping;
-            effectiveDamping = Mathf.Clamp(effectiveDamping, 0f, MaxDamping);
+            // 遅れ時間は秒。末端ほど lagFalloff の分だけ伸びる
+            float lagTime = segment.LagTime * (1f + chainProgress * lagFalloff);
 
-            // t = 1 - damping^(deltaTime * speed) の近似
-            float t = 1f - Mathf.Pow(effectiveDamping, deltaTime * rotationSpeed);
-            t = Mathf.Clamp01(t);
-
-            // 現在の回転から目標回転へ補間
-            Quaternion newRotation = Quaternion.Slerp(segment.CurrentRotation, targetRotation, t);
+            Vector3 angularVelocity = segment.AngularVelocity;
+            Quaternion newRotation = BoneChainSpring.Step(
+                segment.CurrentRotation, targetRotation, ref angularVelocity, lagTime, overshoot, deltaTime);
+            segment.AngularVelocity = angularVelocity;
 
             // 角度制限の適用
             // 折れ曲がりは補間の遅れによって生じるので、目標回転ではなく補間結果に掛ける。
@@ -278,7 +270,7 @@ namespace Blue.Entity.Common
 
                 // 速度は UpdateSegment 内で PreviousPosition を上書きする前に取ってある。
                 // ここで差分を取り直すと同一フレームの値同士になり常にゼロになる
-                branch.UpdateBranch(parentSegment.Velocity, deltaTime, rotationSpeed);
+                branch.UpdateBranch(parentSegment.Velocity, deltaTime);
             }
         }
 


### PR DESCRIPTION
## 概要

`ProceduralBoneChain` の不具合を直したうえで、追従を一次の指数補間からバネ・ダンパへ変更し、パラメータを秒指定に統一する。2 コミットに分かれている。

## 1. 不具合の修正

**ボーン長の参照が 1 つずれていた。** `UpdateSegment` は親からこのボーンまでの距離を使うべきところで `segment.BoneLength` を見ていたが、この値は「このボーンから次まで」の距離で別物。連続するボーン長が等しい区間では偶然一致して露見せず、長さが変わる箇所だけが毎フレーム誤った距離へ引き寄せられていた。FrilledShark では `Spine_Back` が 0.5 のところを 0.375 に縮められ、25% 分メッシュが歪んでいた。

**`maxBendAngle` が機能していなかった。** 初期ローカル回転ではなく現在のローカル回転を渡していたため差分が常に恒等回転になっていた。折れ曲がりは補間の遅れで生じるので、目標回転ではなく補間結果に適用するよう順序も入れ替えている。

**分岐へ渡す親の速度が常にゼロだった。** 同一フレーム内で `PreviousPosition` を上書きした後に差分を取っていたため。分岐側も、慣性を計算しては捨てていた処理を実装し、ボーンの軸を無視していた `LookRotation` とフレームレート依存の補間を直した。

ほか、未使用フィールドの削除、セグメント未設定時の毎フレーム警告、プール時の再初期化。

## 2. バネ・ダンパ化とパラメータ整理

追従が `Quaternion.Slerp` による一次の指数平滑で、目標を行き過ぎることが数学的に起こり得ず揺れ戻りが出せなかった。うねりをアニメーションから外してチェーンに任せる構成にしたところ、揺れの発生源が無くなって動きが硬くなっていた。

角速度を状態として持つ二次系に変更し、`overshoot` で減衰比を指定する（ζ = 1 - overshoot）。駆動周波数が固有振動数に近いと振幅が増えるので、遅れフィルタでは出せなかった曲がり量も稼げる。計算は `BoneChainSpring` へ切り出してメインチェーンと分岐で共用。

あわせてパラメータを置き換えた。`damping` から遅れ時間への変換が τ = -1/(speed × ln(damping)) という双曲線で、1 に近づくと発散する。さらに `dampingFalloff` が加算されるため末端から先に壁へ当たり、実効値 0.95 で τ 1.3 秒、1.0 で 66 秒と事実上そこだけ固まっていた。秒で直接指定する `lagTime` と、乗算で伸ばす `lagFalloff` に変更して壁を無くした。

## 確認

- プレハブは既存設定から τ を逆算して `lagTime` へ焼き込んであるので、パラメータ面での挙動は変わらない
- UnityEngine のスタブを当てて両コミットともコンパイルを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)